### PR TITLE
fix: room-snapshot commands are not exported

### DIFF
--- a/.changeset/flat-lizards-impress.md
+++ b/.changeset/flat-lizards-impress.md
@@ -1,0 +1,5 @@
+---
+'legend-transactional': patch
+---
+
+export room-snapshot commands file. if this file is not exported, then the commands cannot be used when using the library. also, I also changed the order of importing RoomSnapshotCommands in commands.ts

--- a/packages/legend-transac/src/@types/saga/commands/commands.ts
+++ b/packages/legend-transac/src/@types/saga/commands/commands.ts
@@ -11,8 +11,8 @@ import { RoomCreatorCommands } from './roomCreator';
 import { AuthCommands } from './auth';
 import { ShowcaseCommands } from './showcase';
 import { StorageCommands } from './storage';
-import { AvailableMicroservices, availableMicroservices } from '../../microservices';
 import { RoomSnapshotCommands } from './room-snapshot';
+import { AvailableMicroservices, availableMicroservices } from '../../microservices';
 /**
  * A map that defines the relationship between microservices and their corresponding commands.
  */

--- a/packages/legend-transac/src/@types/saga/commands/index.ts
+++ b/packages/legend-transac/src/@types/saga/commands/index.ts
@@ -12,3 +12,4 @@ export * from './roomCreator';
 export * from './showcase';
 export * from './social';
 export * from './storage';
+export * from './room-snapshot';


### PR DESCRIPTION
<!-- Click en Preview -->

### `Changes`

- export room-snapshot.ts (contains RoomSnapshotCommands)
- change the order of importing RoomSnapshotCommands in commands.ts

### `docs`
**export** room-snapshot commands file. if this file is not exported, then the commands cannot be used when using the library. also, I also changed the order of importing RoomSnapshotCommands in commands.ts