### PR TITLE
feat: new microservice room-inventory in AvailableMicroservices

### DIFF
--- a/.changeset/healthy-coats-hide.md
+++ b/.changeset/healthy-coats-hide.md
@@ -1,0 +1,7 @@
+---
+'legend-transactional': patch
+---
+
+new microservice in AvailableMicroservices: room-inventory
+
+'room-inventory' is added to the list of AvailableMicroservices without commands for now, as this microservice is the one that uses commenceSaga for the 'purchase_resource_flow'

--- a/packages/legend-transac/src/@types/microservices.ts
+++ b/packages/legend-transac/src/@types/microservices.ts
@@ -60,7 +60,11 @@ export const availableMicroservices = {
     /**
      * Represents the "room-snapshot" microservice.
      */
-    RoomSnapshot: 'room-snapshot'
+    RoomSnapshot: 'room-snapshot',
+    /**
+     * Represents the "room-inventory" microservice.
+     */
+    RoomInventory: 'room-inventory'
 } as const;
 /**
  * Type of available microservices in the system.

--- a/packages/legend-transac/src/@types/saga/commands/commands.ts
+++ b/packages/legend-transac/src/@types/saga/commands/commands.ts
@@ -13,6 +13,7 @@ import { ShowcaseCommands } from './showcase';
 import { StorageCommands } from './storage';
 import { RoomSnapshotCommands } from './room-snapshot';
 import { AvailableMicroservices, availableMicroservices } from '../../microservices';
+import { RoomInventoryCommands } from './room-inventory';
 /**
  * A map that defines the relationship between microservices and their corresponding commands.
  */
@@ -75,6 +76,10 @@ export interface CommandMap {
      * Represents the mapping of "room-snapshot" microservice commands.
      */
     [availableMicroservices.RoomSnapshot]: RoomSnapshotCommands;
+    /**
+     * Represents the mapping of "room-inventory" microservice commands.
+     */
+    [availableMicroservices.RoomInventory]: RoomInventoryCommands;
 }
 /**
  * Represents a command specific to a microservice.

--- a/packages/legend-transac/src/@types/saga/commands/index.ts
+++ b/packages/legend-transac/src/@types/saga/commands/index.ts
@@ -13,3 +13,4 @@ export * from './showcase';
 export * from './social';
 export * from './storage';
 export * from './room-snapshot';
+export * from './room-inventory';

--- a/packages/legend-transac/src/@types/saga/commands/room-inventory.ts
+++ b/packages/legend-transac/src/@types/saga/commands/room-inventory.ts
@@ -1,0 +1,8 @@
+/**
+ * Different commands related to the "room-inventory" microservice.
+ */
+export const roomInventoryCommands = {} as const;
+/**
+ * Available commands for the "room-inventory" microservice.
+ */
+export type RoomInventoryCommands = (typeof roomInventoryCommands)[keyof typeof roomInventoryCommands];


### PR DESCRIPTION
<!-- Click en Preview -->

### `Changes`

new microservice in AvailableMicroservices: room-inventory

### `docs`

'room-inventory' is added to the list of AvailableMicroservices without commands for now, as this microservice is the one that uses commenceSaga for the 'purchase_resource_flow'
