### PR TITLE
Add notify event in payments to  users

### DIFF
--- a/.changeset/gorgeous-buckets-accept.md
+++ b/.changeset/gorgeous-buckets-accept.md
@@ -1,0 +1,5 @@
+---
+'legend-transactional': minor
+---
+
+New event in payment notify client

--- a/.changeset/gorgeous-buckets-accept.md
+++ b/.changeset/gorgeous-buckets-accept.md
@@ -1,5 +1,6 @@
 ---
-'legend-transactional': minor
+'legend-transactional': patch
 ---
 
-New event in payment notify client
+Added new event payments.notify_client to communicate with the client via web socket in payments server.
+This event will be repeated if the client is not connected to websocket

--- a/packages/legend-transac/src/@types/event/events.ts
+++ b/packages/legend-transac/src/@types/event/events.ts
@@ -41,7 +41,7 @@ export const microserviceEvent = {
     'TEST.IMAGE': 'test.image',
     'TEST.MINT': 'test.mint',
     'SOCIAL.NEW_USER': 'social.new_user',
-    'PAYMENTS.NOTIFY_CLIENT' : 'payments.notify_client'
+    'PAYMENTS.NOTIFY_CLIENT': 'payments.notify_client'
 } as const;
 /**
  * Available microservices events in the system.

--- a/packages/legend-transac/src/@types/event/events.ts
+++ b/packages/legend-transac/src/@types/event/events.ts
@@ -26,6 +26,13 @@ export interface EventPayload {
     'social.new_user': {
         userId: string;
     };
+    /**
+     * Event broadcast by the "Notify Client" payments microservice.
+     */
+    'payments.notify_client': {
+        room: string;
+        message: Record<string, unknown>;
+    };
 }
 /**
  * Represents the available events in the system.
@@ -33,7 +40,8 @@ export interface EventPayload {
 export const microserviceEvent = {
     'TEST.IMAGE': 'test.image',
     'TEST.MINT': 'test.mint',
-    'SOCIAL.NEW_USER': 'social.new_user'
+    'SOCIAL.NEW_USER': 'social.new_user',
+    'PAYMENTS.NOTIFY_CLIENT' : 'payments.notify_client'
 } as const;
 /**
  * Available microservices events in the system.

--- a/packages/legend-transac/src/@types/event/events.ts
+++ b/packages/legend-transac/src/@types/event/events.ts
@@ -30,7 +30,7 @@ export interface EventPayload {
      * Event broadcast by the "Notify Client" payments microservice.
      */
     'payments.notify_client': {
-        room: string;
+        room: `payments-${string}`
         message: Record<string, unknown>;
     };
 }

--- a/packages/legend-transac/src/@types/event/events.ts
+++ b/packages/legend-transac/src/@types/event/events.ts
@@ -30,7 +30,7 @@ export interface EventPayload {
      * Event broadcast by the "Notify Client" payments microservice.
      */
     'payments.notify_client': {
-        room: `payments-${string}`
+        room: `payments-${string}`;
         message: Record<string, unknown>;
     };
 }

--- a/packages/legend-transac/src/@types/event/events.ts
+++ b/packages/legend-transac/src/@types/event/events.ts
@@ -21,13 +21,13 @@ export interface EventPayload {
         mint: string;
     };
     /**
-     * Event broadcast by the "New User" social microservice.
+     * New user in social table in social microservice
      */
     'social.new_user': {
         userId: string;
     };
     /**
-     * Event broadcast by the "Notify Client" payments microservice.
+     * Websocket event to notify the client about a payment related event.
      */
     'payments.notify_client': {
         room: `payments-${string}`;


### PR DESCRIPTION
## Changes
Added new event payments.notify_client to communicate with the client via web socket in payments server.
Defined payload for the event

## docs

Added new event payments.notify_client to communicate with the client via web socket in payments server.
This event will be repeated if the client is not connected to websocket

## Issue 
https://legendaryum.atlassian.net/browse/LE-1802