### PR TITLE
feat: new field in purchase_resource_flow payload

### DIFF
--- a/.changeset/shy-insects-draw.md
+++ b/.changeset/shy-insects-draw.md
@@ -1,0 +1,5 @@
+---
+'legend-transactional': patch
+---
+
+new field in purchase_resource_flow payload. this will serve to store the unityId in room-snapshot, a microservice responsible for managing the resources owned by a user

--- a/packages/legend-transac/src/@types/saga/commence.ts
+++ b/packages/legend-transac/src/@types/saga/commence.ts
@@ -26,6 +26,7 @@ export interface SagaCommencePayload {
         resourceId: string;
         price: number;
         quantity: number;
+        unityId: string;
     };
 }
 


### PR DESCRIPTION
<!-- Click en Preview -->

### `Changes`

- new field in purchase_resource_flow payload

### `docs`
this will serve to store the unityId in room-snapshot, a microservice responsible for managing the resources owned by a user
