### PR TITLE
feat: the type of unityId has been changed from string to number

### DIFF
--- a/.changeset/twelve-rocks-happen.md
+++ b/.changeset/twelve-rocks-happen.md
@@ -1,0 +1,5 @@
+---
+'legend-transactional': patch
+---
+
+change the type of unityId has been changed from string to number

--- a/packages/legend-transac/src/@types/saga/commence.ts
+++ b/packages/legend-transac/src/@types/saga/commence.ts
@@ -26,7 +26,7 @@ export interface SagaCommencePayload {
         resourceId: string;
         price: number;
         quantity: number;
-        unityId: string;
+        unityId: number;
     };
 }
 


### PR DESCRIPTION
<!-- Click en Preview -->

### `Changes`

- the type of unityId has been changed from string to number

### `docs`

the type of unityId has been changed from string to number. this is the number that Unity stores for all the resources
