### PR TITLE
feat: new event to duplicate minimal user data

### DIFF
--- a/.changeset/great-geckos-impress.md
+++ b/.changeset/great-geckos-impress.md
@@ -1,0 +1,5 @@
+---
+'legend-transactional': patch
+---
+
+new event to duplicate minimal user data in the microservice that listens to it. this occurs when the user is created

--- a/.changeset/witty-dingos-doubt.md
+++ b/.changeset/witty-dingos-doubt.md
@@ -1,0 +1,5 @@
+---
+'legend-transactional': patch
+---
+
+new event to duplicate minimal user data in the microservice that listens to it

--- a/.changeset/witty-dingos-doubt.md
+++ b/.changeset/witty-dingos-doubt.md
@@ -1,5 +1,0 @@
----
-'legend-transactional': patch
----
-
-new event to duplicate minimal user data in the microservice that listens to it

--- a/packages/legend-transac/src/@types/event/events.ts
+++ b/packages/legend-transac/src/@types/event/events.ts
@@ -73,6 +73,13 @@ export interface EventPayload {
         userId: string;
     };
     /**
+     * Event to duplicate minimal user data in the microservice that listens to it.
+     */
+    'auth.duplicate_minimal_user_data': {
+        id: string;
+        email: string;
+    };
+    /**
      * Event to logout a user.
      */
     'auth.logout_user': {
@@ -183,6 +190,7 @@ export const microserviceEvent = {
     'TEST.MINT': 'test.mint',
     ///////////////////////////
     'AUTH.DELETED_USER': 'auth.deleted_user',
+    'AUTH.DUPLICATE_MINIMAL_USER_DATA': 'auth.duplicate_minimal_user_data',
     'AUTH.LOGOUT_USER': 'auth.logout_user',
     'COINS.NOTIFY_CLIENT': 'coins.notify_client',
     'COINS.SEND_EMAIL': 'coins.send_email',

--- a/packages/legend-transac/src/@types/event/events.ts
+++ b/packages/legend-transac/src/@types/event/events.ts
@@ -73,17 +73,19 @@ export interface EventPayload {
         userId: string;
     };
     /**
-     * Event to duplicate minimal user data in the microservice that listens to it.
-     */
-    'auth.duplicate_minimal_user_data': {
-        id: string;
-        email: string;
-    };
-    /**
      * Event to logout a user.
      */
     'auth.logout_user': {
         userId: string;
+    };
+    /**
+     * Event to duplicate minimal user data in the microservice that listens to it. This occurs when the user is created.
+     */
+    'auth.new_user': {
+        id: string;
+        email: string;
+        username: string;
+        userlastname: string;
     };
     /**
      * Event to update a user's subscription.
@@ -190,8 +192,8 @@ export const microserviceEvent = {
     'TEST.MINT': 'test.mint',
     ///////////////////////////
     'AUTH.DELETED_USER': 'auth.deleted_user',
-    'AUTH.DUPLICATE_MINIMAL_USER_DATA': 'auth.duplicate_minimal_user_data',
     'AUTH.LOGOUT_USER': 'auth.logout_user',
+    'AUTH.NEW_USER': 'auth.new_user',
     'COINS.NOTIFY_CLIENT': 'coins.notify_client',
     'COINS.SEND_EMAIL': 'coins.send_email',
     'COINS.UPDATE_SUBSCRIPTION': 'coins.update_subscription',


### PR DESCRIPTION
<!-- Click en Preview -->

### `Changes`

- New event `auth.duplicate_minimal_user_data` to duplicate minimal user data in the microservice that listens to it.

### `docs`

- New event `auth.duplicate_minimal_user_data` to duplicate minimal user data in the microservice that listens to it.
- For now, it will emit two pieces of data: the ID of the newly created user and their email. Both fields are strings.