### PR TITLE
feat: new event 'legend_rankings.crypto_ranking_finished'

### DIFF
--- a/.changeset/curly-brooms-rhyme.md
+++ b/.changeset/curly-brooms-rhyme.md
@@ -1,0 +1,5 @@
+---
+'legend-transactional': patch
+---
+
+new event 'legend_rankings.crypto_ranking_finished'

--- a/packages/legend-transac/src/@types/event/events.ts
+++ b/packages/legend-transac/src/@types/event/events.ts
@@ -123,6 +123,11 @@ export interface SocialUser {
     createdAt: Date;
 }
 
+export interface CompletedCryptoRanking {
+    walletAddress: string;
+    winners: RankingWinners[];
+}
+
 /**
  * Represents the available event's payload in the system.
  */
@@ -202,6 +207,12 @@ export interface EventPayload {
      */
     'legend_missions.ongoing_mission': {
         redisKey: string;
+    };
+    /**
+     * Event to send crypto rewards to the winners of a ranking
+     */
+    'legend_rankings.crypto_ranking_finished': {
+        completedCryptoRankings: CompletedCryptoRanking[];
     };
     /**
      * Event to send emails to winners when the ranking finishes
@@ -291,6 +302,7 @@ export const microserviceEvent = {
     'COINS.UPDATE_SUBSCRIPTION': 'coins.update_subscription',
     'LEGEND_MISSIONS.COMPLETED_MISSION_REWARD': 'legend_missions.completed_mission_reward',
     'LEGEND_MISSIONS.ONGOING_MISSION': 'legend_missions.ongoing_mission',
+    'LEGEND_RANKINGS.CRYPTO_RANKING_FINISHED': 'legend_rankings.crypto_ranking_finished',
     'LEGEND_RANKINGS.RANKINGS_FINISHED': 'legend_rankings.rankings_finished',
     'ROOM_CREATOR.CREATED_ROOM': 'room_creator.created_room',
     'ROOM_CREATOR.UPDATED_ROOM': 'room_creator.updated_room',


### PR DESCRIPTION
<!-- Click en Preview -->

### `Changes`

- new event 'legend_rankings.crypto_ranking_finished'

### `docs`

- new event 'legend_rankings.crypto_ranking_finished'
- event to ensure that when a ranking with crypto rewards is closed, the information is sent to 'legend-blockchain' to perform the transfers via the blockchain.
