### PR TITLE
feat: crypto ranking reward amount from number to string

### DIFF
--- a/.changeset/giant-bags-attend.md
+++ b/.changeset/giant-bags-attend.md
@@ -1,0 +1,5 @@
+---
+'legend-transactional': patch
+---
+
+feat: crypto ranking reward from f64 to string

--- a/packages/legend-transac/src/@types/saga/commence.ts
+++ b/packages/legend-transac/src/@types/saga/commence.ts
@@ -34,7 +34,7 @@ export interface SagaCommencePayload {
             walletAddress: string;
             winners: {
                 userId: string;
-                reward: number;
+                reward: string;
             }[];
         }[];
     };


### PR DESCRIPTION
<!-- Click en Preview -->

### `Changes`

This pull request includes a change to the `legend-transactional/packages/legend-transac/src/@types/saga/commence.ts` file. The change modifies the `['transfer_crypto_reward_to_ranking_winners']` saga to change the type of the `reward` field from `number` to `string`.

### `docs`
Changed the type of the `reward` field in the `['transfer_crypto_reward_to_ranking_winners']` saga from `number` to `string` to ensure proper handling of reward values.
