### PR TITLE
feat: event replacement by a saga to transfer rewards from a crypto mission

### DIFF
--- a/.changeset/three-parents-punch.md
+++ b/.changeset/three-parents-punch.md
@@ -1,0 +1,5 @@
+---
+'legend-transactional': patch
+---
+
+event replacement by a saga to transfer rewards from a crypto mission

--- a/packages/legend-transac/src/@types/event/events.ts
+++ b/packages/legend-transac/src/@types/event/events.ts
@@ -203,17 +203,6 @@ export interface EventPayload {
         coins: number;
     };
     /**
-     * Event to notify that a user has completed a mission with crypto reward
-     */
-    'legend_missions.crypto_mission_completed': {
-        // Wallet address from which rewards will be transferred
-        walletAddress: string;
-        // ID of the user who completed the mission
-        userId: string;
-        // Amount to be transferred
-        reward: string;
-    };
-    /**
      * Event to notify the mission's author that it has been created
      */
     'legend_missions.new_mission_created': {
@@ -340,7 +329,6 @@ export const microserviceEvent = {
     'COINS.SEND_EMAIL': 'coins.send_email',
     'COINS.UPDATE_SUBSCRIPTION': 'coins.update_subscription',
     'LEGEND_MISSIONS.COMPLETED_MISSION_REWARD': 'legend_missions.completed_mission_reward',
-    'LEGEND_MISSIONS.CRYPTO_MISSION_COMPLETED': 'legend_missions.crypto_mission_completed',
     'LEGEND_MISSIONS.NEW_MISSION_CREATED': 'legend_missions.new_mission_created',
     'LEGEND_MISSIONS.ONGOING_MISSION': 'legend_missions.ongoing_mission',
     'LEGEND_RANKINGS.RANKINGS_FINISHED': 'legend_rankings.rankings_finished',

--- a/packages/legend-transac/src/@types/saga/commands/blockchain.ts
+++ b/packages/legend-transac/src/@types/saga/commands/blockchain.ts
@@ -5,7 +5,11 @@ export const blockchainCommands = {
     /**
      * Saga step to make transfers to winners.
      */
-    TransferRewardToWinners: 'crypto_reward:transfer_reward_to_winners'
+    TransferRewardToWinners: 'crypto_reward:transfer_reward_to_winners',
+    /**
+     * Saga step to transfer crypto reward to the winner of a mission.
+     */
+    TransferMissionRewardToWinner: 'crypto_reward:transfer_mission_reward_to_winner'
 } as const;
 /**
  * Available commands for the "blockchain" microservice.

--- a/packages/legend-transac/src/@types/saga/commence.ts
+++ b/packages/legend-transac/src/@types/saga/commence.ts
@@ -10,6 +10,10 @@ export const sagaTitle = {
      */
     RankingsUsersReward: 'rankings_users_reward',
     /**
+     * Saga used to initiate a crypto transfer for a mission winner.
+     */
+    TransferCryptoRewardToMissionWinner: 'transfer_crypto_reward_to_mission_winner',
+    /**
      * Saga used to initiate a crypto transfer for ranking winners.
      */
     TransferCryptoRewardToRankingWinners: 'transfer_crypto_reward_to_ranking_winners'
@@ -28,6 +32,14 @@ export interface SagaCommencePayload {
     };
     ['rankings_users_reward']: {
         rewards: { userId: string; coins: number }[];
+    };
+    ['transfer_crypto_reward_to_mission_winner']: {
+        // Wallet address from which rewards will be transferred
+        walletAddress: string;
+        // ID of the user who completed the mission
+        userId: string;
+        // Amount to be transferred
+        reward: string;
     };
     ['transfer_crypto_reward_to_ranking_winners']: {
         completedCryptoRankings: {


### PR DESCRIPTION
<!-- Click en Preview -->

### `Changes`

- event replacement by a saga to transfer rewards from a crypto mission

### `docs`

- event replacement by a saga to transfer rewards from a crypto mission
- docs in file
