### PR TITLE
refactor(types): change socialMedia to Record and reward to string in crypto mission event

### DIFF
--- a/.changeset/long-ghosts-look.md
+++ b/.changeset/long-ghosts-look.md
@@ -1,0 +1,5 @@
+---
+'legend-transactional': minor
+---
+
+events: set crypto reward to string; SocialUser.socialMedia -> Record<string, string>

--- a/packages/legend-transac/src/@types/event/events.ts
+++ b/packages/legend-transac/src/@types/event/events.ts
@@ -119,7 +119,7 @@ export interface SocialUser {
   userImage?: string;
   glbUrl?: string;
   description?: string;
-  socialMedia?: Map<string, string>;
+  socialMedia?: Record<string, string>;
   preferences: string[];
   blockedUsers: string[];
   RPMAvatarId?: string;
@@ -227,7 +227,7 @@ export interface EventPayload {
   'legend_missions.send_email_crypto_mission_completed': {
     userId: string;
     missionTitle: string;
-    reward: number;
+    reward: string;
     blockchainNetwork: string;
     cryptoAsset: string;
   };


### PR DESCRIPTION
TICKET:

> https://legendaryum.atlassian.net/jira/software/projects/LE/boards/1?jql=assignee%20%3D%20712020%3A0ba71cb3-687c-42cf-9f25-4b1eb799e981&selectedIssue=LE-3416

RESUMEN:
Reaplica los cambios del ticket LE-3416, previamente revertidos, que actualizan:

- El tipo de socialMedia.
- El tipo de reward para el evento de misión crypto.

Contexto
El cambio original se había mergeado pero fue revertido posteriormente. Este PR vuelve a incorporar dichos ajustes para que queden disponibles y actualizados en la rama principal.