### PR TITLE
chore: complete the legend_missions.mission_finished event payload

### DIFF
--- a/.changeset/warm-plums-talk.md
+++ b/.changeset/warm-plums-talk.md
@@ -1,0 +1,5 @@
+---
+'legend-transactional': patch
+---
+
+add payload event 'legend_missions.mission_finished

--- a/packages/legend-transac/src/@types/event/events.ts
+++ b/packages/legend-transac/src/@types/event/events.ts
@@ -226,6 +226,17 @@ export interface EventPayload {
     redisKey: string;
   };
   /**
+   * Event triggered when a mission finishes and needs to send final reports to participants
+   */
+  'legend_missions.mission_finished': {
+    missionTitle: string;
+    participants: Array<{
+      userId?: string;
+      email?: string;
+      position?: number;
+    }>;
+  };
+  /**
    * Event triggered to send an email notification when a user completes a crypto-based mission and earns a reward.
    */
   'legend_missions.send_email_crypto_mission_completed': {


### PR DESCRIPTION
Descripción:
Completa la definición del evento `legend_missions.mission_finished` agregando el payload faltante en `EventPayload`.
