### PR TITLE
feat(events): add intermediate rewards support

### DIFF
--- a/.changeset/fresh-bikes-fail.md
+++ b/.changeset/fresh-bikes-fail.md
@@ -1,0 +1,5 @@
+---
+'legend-transactional': patch
+---
+
+add intermediate rewards support

--- a/packages/legend-transac/src/@types/event/events.ts
+++ b/packages/legend-transac/src/@types/event/events.ts
@@ -280,6 +280,17 @@ export interface EventPayload {
     completedRankings: CompletedRanking[];
   };
   /**
+   * Event to deliver intermediate reward (e.g., first game)
+   */
+  'legend_rankings.intermediate_reward': {
+    userId: string;
+    rankingId: number;
+    intermediateRewardType: string;
+    rewardConfig: Record<string, unknown>;
+    templateName: string;
+    templateData: Record<string, unknown>;
+  };
+  /**
    * Event to notify when a ranking is created
    */
   'legend_rankings.new_ranking_created': {
@@ -408,6 +419,7 @@ export const microserviceEvent = {
   'LEGEND_MISSIONS.SEND_EMAIL_NFT_MISSION_COMPLETED': 'legend_missions.send_email_nft_mission_completed',
   'LEGEND_RANKINGS.RANKINGS_FINISHED': 'legend_rankings.rankings_finished',
   'LEGEND_RANKINGS.NEW_RANKING_CREATED': 'legend_rankings.new_ranking_created',
+  'LEGEND_RANKINGS.INTERMEDIATE_REWARD': 'legend_rankings.intermediate_reward',
   'LEGEND_SHOWCASE.PRODUCT_VIRTUAL_DELETED': 'legend_showcase.product_virtual_deleted',
   'LEGEND_SHOWCASE.UPDATE_ALLOWED_MISSION_SUBSCRIPTION_IDS': 'legend_showcase.update_allowed_mission_subscription_ids',
   'LEGEND_SHOWCASE.UPDATE_ALLOWED_RANKING_SUBSCRIPTION_IDS': 'legend_showcase.update_allowed_ranking_subscription_ids',


### PR DESCRIPTION
## Ticket:
https://legendaryum.atlassian.net/browse/LE-3640

## Resumen
Se agregó soporte para evento legend_rankings.intermediate_reward que entrega recompensas automáticas durante participación activa en rankings, de momento se entregara solo al hito de la primera partida (first_game,) que es lo que se pidio (puede llegar a escalar en un futuro con otros hitos y tipos de reward.

## Uso
Se emite cuando usuarios alcanzan milestones específicos desde Rankings hacia microservicios de email. Utiliza `Record<string, unknown>` para `rewardConfig` y `templateData` para garantizar flexibilidad y compatibilidad con futuras extensiones del sistema de rewards.


