### PR TITLE
feat: add legend-game-analytics to available microservices

### DIFF
--- a/.changeset/legal-bats-burn.md
+++ b/.changeset/legal-bats-burn.md
@@ -1,0 +1,5 @@
+---
+'legend-transactional': patch
+---
+
+add legend-game-analytics to available microservices

--- a/packages/legend-transac/src/@types/microservices.ts
+++ b/packages/legend-transac/src/@types/microservices.ts
@@ -64,6 +64,10 @@ export const availableMicroservices = {
    * Represents the "legend-storage" microservice.
    */
   Storage: 'legend-storage',
+  /**
+   * Represents the "legend-game-analytics" microservice.
+   */
+  LegendGameAnalytics: 'legend-game-analytics',
 } as const;
 /**
  * Type of available microservices in the system.

--- a/packages/legend-transac/src/@types/saga/commands/commands.ts
+++ b/packages/legend-transac/src/@types/saga/commands/commands.ts
@@ -13,6 +13,7 @@ import { AuditEdaCommands } from './audit-eda';
 import { TransactionalCommands } from './transactional';
 import { BillingCommands } from './billing';
 import { LegendEventsCommands } from './legend_events';
+import { LegendGameAnalyticsCommands } from './legend-game-analytics';
 /**
  * A map that defines the relationship between microservices and their corresponding commands.
  */
@@ -75,6 +76,10 @@ export interface CommandMap {
    * Represents the mapping of "legend-events" microservice commands.
    */
   [availableMicroservices.Events]: LegendEventsCommands;
+  /**
+   * Represents the mapping of "legend-game-analytics" microservice commands.
+   */
+  [availableMicroservices.LegendGameAnalytics]: LegendGameAnalyticsCommands;
 }
 /**
  * Represents a command specific to a microservice.

--- a/packages/legend-transac/src/@types/saga/commands/legend-game-analytics.ts
+++ b/packages/legend-transac/src/@types/saga/commands/legend-game-analytics.ts
@@ -1,0 +1,8 @@
+/**
+ * Different commands related to the "legend-game-analytics" microservice.
+ */
+export const legendGameAnalyticsCommands = {} as const;
+/**
+ * Available commands for the "legend-game-analytics" microservice.
+ */
+export type LegendGameAnalyticsCommands = (typeof legendGameAnalyticsCommands)[keyof typeof legendGameAnalyticsCommands];

--- a/packages/legend-transac/src/@types/saga/commands/legend-game-analytics.ts
+++ b/packages/legend-transac/src/@types/saga/commands/legend-game-analytics.ts
@@ -5,4 +5,5 @@ export const legendGameAnalyticsCommands = {} as const;
 /**
  * Available commands for the "legend-game-analytics" microservice.
  */
-export type LegendGameAnalyticsCommands = (typeof legendGameAnalyticsCommands)[keyof typeof legendGameAnalyticsCommands];
+export type LegendGameAnalyticsCommands =
+  (typeof legendGameAnalyticsCommands)[keyof typeof legendGameAnalyticsCommands];


### PR DESCRIPTION
### Ticket 
https://legendaryum.atlassian.net/browse/LE-4053

### Resumen:
- Se actualizó la constante availableMicroservices en @types/microservices.ts.
- Esto permite que los servicios en Node/TS reconozcan al micro de analíticas para flujos transaccionales y de auditoría.
