### PR TITLE
chore: rename to @legend-libs/transactional (v3.0.0)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -118,7 +118,7 @@ jobs:
                         "type": "plain_text",
                         "text": "npm library"
                       },
-                      "url": "https://www.npmjs.com/package/legend-transactional"
+                      "url": "https://www.npmjs.com/package/@legend-libs/transactional"
                     }
                   ]
                 }            

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# `legend-transactional`
+# `@legend-libs/transactional`
 
 <div style="text-align: center;">
   <br/>
@@ -10,15 +10,15 @@
 
 [![GitHub Workflow Status](https://img.shields.io/github/actions/workflow/status/legendaryum-metaverse/legend-transactional/release.yml?branch=main)](https://github.com/legendaryum-metaverse/legend-transactional/tree/main/packages/legend-transac)
 [![GitHub](https://img.shields.io/github/license/legendaryum-metaverse/legend-transactional)](https://github.com/legendaryum-metaverse/legend-transactional/blob/main/LICENSE)
-[![npm](https://img.shields.io/npm/v/legend-transactional)](https://www.npmjs.com/package/legend-transactional)
-[![npm](https://img.shields.io/npm/dm/legend-transactional)](https://www.npmjs.com/package/legend-transactional)
-[![Bundle Size](https://img.shields.io/bundlephobia/min/legend-transactional)](https://bundlephobia.com/result?p=legend-transactional)
-[![Bundle Size](https://img.shields.io/bundlephobia/minzip/legend-transactional)](https://bundlephobia.com/result?p=legend-transactional)
-[![npm type definitions](https://img.shields.io/npm/types/legend-transactional)](https://www.npmjs.com/package/legend-transactional)
+[![npm](https://img.shields.io/npm/v/@legend-libs/transactional)](https://www.npmjs.com/package/@legend-libs/transactional)
+[![npm](https://img.shields.io/npm/dm/@legend-libs/transactional)](https://www.npmjs.com/package/@legend-libs/transactional)
+[![Bundle Size](https://img.shields.io/bundlephobia/min/@legend-libs/transactional)](https://bundlephobia.com/result?p=@legend-libs/transactional)
+[![Bundle Size](https://img.shields.io/bundlephobia/minzip/@legend-libs/transactional)](https://bundlephobia.com/result?p=@legend-libs/transactional)
+[![npm type definitions](https://img.shields.io/npm/types/@legend-libs/transactional)](https://www.npmjs.com/package/@legend-libs/transactional)
 [![GitHub commit activity](https://img.shields.io/github/commit-activity/m/legendaryum-metaverse/legend-transactional)](https://github.com/legendaryum-metaverse/legend-transactional/pulse)
 [![GitHub last commit](https://img.shields.io/github/last-commit/legendaryum-metaverse/legend-transactional)](https://github.com/legendaryum-metaverse/legend-transactional/commits/main)
 
-[**legend-transactional**](https://www.npmjs.com/package/legend-transactional) is a Node.js/TypeScript library designed to streamline communication
+[**@legend-libs/transactional**](https://www.npmjs.com/package/@legend-libs/transactional) is a Node.js/TypeScript library designed to streamline communication
 between microservices using RabbitMQ. It enables easy implementation of event-driven architectures and saga patterns, while ensuring reliable message delivery.
 
 ## Features

--- a/apps/image/package.json
+++ b/apps/image/package.json
@@ -5,7 +5,7 @@
   "main": "./dist/server.js",
   "private": true,
   "dependencies": {
-    "legend-transactional": "workspace:*",
+    "@legend-libs/transactional": "workspace:*",
     "express": "latest"
   },
   "devDependencies": {

--- a/apps/image/src/handler.ts
+++ b/apps/image/src/handler.ts
@@ -1,4 +1,4 @@
-import { MicroserviceHandler, CommandMap } from 'legend-transactional';
+import { MicroserviceHandler, CommandMap } from '@legend-libs/transactional';
 
 const waitWithMessage = async (msg: string, time: number) => {
   await new Promise((resolve) => setTimeout(resolve, time));

--- a/apps/image/src/server.ts
+++ b/apps/image/src/server.ts
@@ -1,5 +1,5 @@
 import express, { Request, Response } from 'express';
-import { Saga, stopRabbitMQ } from 'legend-transactional';
+import { Saga, stopRabbitMQ } from '@legend-libs/transactional';
 import { handler } from './handler';
 
 const app = express();

--- a/apps/mint/package.json
+++ b/apps/mint/package.json
@@ -5,7 +5,7 @@
   "main": "./dist/server.js",
   "private": true,
   "dependencies": {
-    "legend-transactional": "workspace:*",
+    "@legend-libs/transactional": "workspace:*",
     "express": "latest"
   },
   "devDependencies": {

--- a/apps/mint/src/handler.ts
+++ b/apps/mint/src/handler.ts
@@ -1,4 +1,4 @@
-import { MicroserviceHandler } from 'legend-transactional';
+import { MicroserviceHandler } from '@legend-libs/transactional';
 
 const needToRequeueWithDelay = () => {
   return Math.random() >= 0.6;

--- a/apps/mint/src/server.ts
+++ b/apps/mint/src/server.ts
@@ -1,5 +1,5 @@
 import express, { Request, Response } from 'express';
-import { Saga, stopRabbitMQ } from 'legend-transactional';
+import { Saga, stopRabbitMQ } from '@legend-libs/transactional';
 import { handler } from './handler';
 
 const app = express();

--- a/apps/saga/package.json
+++ b/apps/saga/package.json
@@ -5,7 +5,7 @@
   "main": "./dist/server.js",
   "private": true,
   "dependencies": {
-    "legend-transactional": "workspace:*",
+    "@legend-libs/transactional": "workspace:*",
     "express": "latest"
   },
   "devDependencies": {

--- a/apps/saga/src/handler.ts
+++ b/apps/saga/src/handler.ts
@@ -1,4 +1,4 @@
-import { AvailableMicroservices, CommandMap, SagaHandler } from 'legend-transactional';
+import { AvailableMicroservices, CommandMap, SagaHandler } from '@legend-libs/transactional';
 
 export const handler = (
   command: CommandMap[AvailableMicroservices],

--- a/apps/saga/src/server.ts
+++ b/apps/saga/src/server.ts
@@ -1,5 +1,5 @@
 import express, { Request, Response } from 'express';
-import { stopRabbitMQ, Transactional } from 'legend-transactional';
+import { stopRabbitMQ, Transactional } from '@legend-libs/transactional';
 import { handler } from './handler';
 
 const app = express();

--- a/packages/legend-transac/README.md
+++ b/packages/legend-transac/README.md
@@ -1,4 +1,4 @@
-# `legend-transactional`
+# `@legend-libs/transactional`
 
 <div style="text-align: center;">
   <br/>
@@ -10,15 +10,15 @@
 
 [![GitHub Workflow Status](https://img.shields.io/github/actions/workflow/status/legendaryum-metaverse/legend-transactional/release.yml?branch=main)](https://github.com/legendaryum-metaverse/legend-transactional/tree/main/packages/legend-transac)
 [![GitHub](https://img.shields.io/github/license/legendaryum-metaverse/legend-transactional)](https://github.com/legendaryum-metaverse/legend-transactional/blob/main/LICENSE)
-[![npm](https://img.shields.io/npm/v/legend-transactional)](https://www.npmjs.com/package/legend-transactional)
-[![npm](https://img.shields.io/npm/dm/legend-transactional)](https://www.npmjs.com/package/legend-transactional)
-[![Bundle Size](https://img.shields.io/bundlephobia/min/legend-transactional)](https://bundlephobia.com/result?p=legend-transactional)
-[![Bundle Size](https://img.shields.io/bundlephobia/minzip/legend-transactional)](https://bundlephobia.com/result?p=legend-transactional)
-[![npm type definitions](https://img.shields.io/npm/types/legend-transactional)](https://www.npmjs.com/package/legend-transactional)
+[![npm](https://img.shields.io/npm/v/@legend-libs/transactional)](https://www.npmjs.com/package/@legend-libs/transactional)
+[![npm](https://img.shields.io/npm/dm/@legend-libs/transactional)](https://www.npmjs.com/package/@legend-libs/transactional)
+[![Bundle Size](https://img.shields.io/bundlephobia/min/@legend-libs/transactional)](https://bundlephobia.com/result?p=@legend-libs/transactional)
+[![Bundle Size](https://img.shields.io/bundlephobia/minzip/@legend-libs/transactional)](https://bundlephobia.com/result?p=@legend-libs/transactional)
+[![npm type definitions](https://img.shields.io/npm/types/@legend-libs/transactional)](https://www.npmjs.com/package/@legend-libs/transactional)
 [![GitHub commit activity](https://img.shields.io/github/commit-activity/m/legendaryum-metaverse/legend-transactional)](https://github.com/legendaryum-metaverse/legend-transactional/pulse)
 [![GitHub last commit](https://img.shields.io/github/last-commit/legendaryum-metaverse/legend-transactional)](https://github.com/legendaryum-metaverse/legend-transactional/commits/main)
 
-[**legend-transactional**](https://www.npmjs.com/package/legend-transactional) is a Node.js/TypeScript library designed to streamline communication
+[**@legend-libs/transactional**](https://www.npmjs.com/package/@legend-libs/transactional) is a Node.js/TypeScript library designed to streamline communication
 between microservices using RabbitMQ. It enables easy implementation of event-driven architectures and saga patterns, while ensuring reliable message delivery.
 
 ## Features

--- a/packages/legend-transac/package.json
+++ b/packages/legend-transac/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "legend-transactional",
-  "version": "2.6.7",
+  "name": "@legend-libs/transactional",
+  "version": "3.0.0",
   "description": "A simple transactional, event-driven communication framework for microservices using RabbitMQ",
   "author": "Jorge Clavijo <jym272@gmail.com> (https://github.com/jym272)",
   "license": "MIT",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -105,12 +105,12 @@ importers:
 
   apps/image:
     dependencies:
+      '@legend-libs/transactional':
+        specifier: workspace:*
+        version: link:../../packages/legend-transac
       express:
         specifier: latest
         version: 5.2.1
-      legend-transactional:
-        specifier: workspace:*
-        version: link:../../packages/legend-transac
     devDependencies:
       '@types/express':
         specifier: latest
@@ -121,12 +121,12 @@ importers:
 
   apps/mint:
     dependencies:
+      '@legend-libs/transactional':
+        specifier: workspace:*
+        version: link:../../packages/legend-transac
       express:
         specifier: latest
         version: 5.2.1
-      legend-transactional:
-        specifier: workspace:*
-        version: link:../../packages/legend-transac
     devDependencies:
       '@types/express':
         specifier: latest
@@ -137,12 +137,12 @@ importers:
 
   apps/saga:
     dependencies:
+      '@legend-libs/transactional':
+        specifier: workspace:*
+        version: link:../../packages/legend-transac
       express:
         specifier: latest
         version: 5.2.1
-      legend-transactional:
-        specifier: workspace:*
-        version: link:../../packages/legend-transac
     devDependencies:
       '@types/express':
         specifier: latest

--- a/turbo.json
+++ b/turbo.json
@@ -23,22 +23,22 @@
       "env": ["PORT", "RABBIT_URI"]
     },
     "saga#type-check": {
-      "dependsOn": ["legend-transactional#build:dev"],
+      "dependsOn": ["@legend-libs/transactional#build:dev"],
       "inputs": ["src/**"]
     },
     "micro-image#type-check": {
-      "dependsOn": ["legend-transactional#build:dev"],
+      "dependsOn": ["@legend-libs/transactional#build:dev"],
       "inputs": ["src/**"]
     },
     "micro-mint#type-check": {
-      "dependsOn": ["legend-transactional#build:dev"],
+      "dependsOn": ["@legend-libs/transactional#build:dev"],
       "inputs": ["src/**"]
     },
     "type-check": {
       "inputs": ["src/**"]
     },
     "dev": {
-      "dependsOn": ["legend-transactional#build:dev"],
+      "dependsOn": ["@legend-libs/transactional#build:dev"],
       "cache": false,
       "persistent": true
     },


### PR DESCRIPTION
## Summary

- Old `legend-transactional` lived on a locked CTO npm account. Republished under the new **legend-libs** org as **@legend-libs/transactional@3.0.0** (already published manually to bootstrap the new package).
- This PR aligns the source tree, internal apps, CI Slack notification, and READMEs with the new name.

## Changes

- `packages/legend-transac/package.json`: `name` → `@legend-libs/transactional`, `version` → `3.0.0`
- `apps/{image,mint,saga}`: dep keys (`workspace:*`) and TS imports updated
- `turbo.json`: task graph references `@legend-libs/transactional#build:dev`
- `.github/workflows/release.yml` (line 121): Slack URL points to new npm package page
- `README.md` + `packages/legend-transac/README.md`: title, badges, npm links

## Not in this PR

- No changeset added — `3.0.0` was published manually outside the changesets flow. CI will run `release.yml` on merge but should be a no-op (no changesets to consume).
- A follow-up PR will add a changeset to exercise the full CD path (expected to publish `3.0.1`).

## Test plan

- [x] `pnpm install` succeeds (lockfile refreshed)
- [x] `pnpm run build` — all 5 turbo tasks pass
- [x] `pnpm run type-check` — all 6 turbo tasks pass
- [x] Manual publish to npm verified at https://www.npmjs.com/package/@legend-libs/transactional
- [ ] CI on this PR is green
- [ ] After merge: `release.yml` runs and is a no-op (no version bump, no publish)

🤖 Generated with [Claude Code](https://claude.com/claude-code)