### PR TITLE
chore: validate release CI under new @legend-libs scope

### DIFF
--- a/.changeset/test-release-flow.md
+++ b/.changeset/test-release-flow.md
@@ -1,0 +1,5 @@
+---
+'@legend-libs/transactional': patch
+---
+
+Validate release CI publishes under new @legend-libs scope.

--- a/packages/legend-transac/src/index.ts
+++ b/packages/legend-transac/src/index.ts
@@ -4,4 +4,4 @@ export * from './Connections';
 export * from './constants';
 export * from './Consumer';
 export * from './utils';
-// dummy comment
+// dummy comment to trigger CI on changeset-only PR


### PR DESCRIPTION
## Summary

- Adds a single patch changeset for `@legend-libs/transactional`.
- Goal: exercise the full `release.yml` flow under the new npm scope and the new `NPM_TOKEN`.

## Expected behavior on merge

1. `release.yml` runs on push to `main`.
2. `changesets/action` opens a `[ci] release` PR (since `publish` only fires when version PR is merged).
3. Merging that release PR triggers another `release.yml` run that **publishes `@legend-libs/transactional@3.0.1`** to npm and posts the Slack notification.

## Test plan

- [ ] CI green on this PR
- [ ] After merge: changeset release PR auto-opens
- [ ] Merging release PR publishes `3.0.1` to https://www.npmjs.com/package/@legend-libs/transactional
- [ ] Slack notification fires with new package URL

🤖 Generated with [Claude Code](https://claude.com/claude-code)