### PR TITLE
ci: switch release.yml to npm trusted publishing (OIDC)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,6 +17,7 @@ env:
   #  TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
   #  TURBO_TEAM: ${{ secrets.TURBO_TEAM }}
   FORCE_COLOR: 3
+  NPM_CONFIG_PROVENANCE: true
 
 jobs:
   changelog:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,10 +20,14 @@ env:
 
 jobs:
   changelog:
-    timeout-minutes: 2
+    timeout-minutes: 5
     if: github.event.repository.full_name == github.repository
     name: Changelog PR or Release
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+      id-token: write
     steps:
       - uses: actions/checkout@v4
 
@@ -32,8 +36,12 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22
           cache: 'pnpm'
+          registry-url: 'https://registry.npmjs.org'
+
+      - name: Upgrade npm for trusted publishing (OIDC)
+        run: npm install -g npm@latest
 
       - name: Install dependencies
         run: pnpm install
@@ -51,10 +59,7 @@ jobs:
           commit: '[ci] release'
           title: '[ci] release'
         env:
-          # Needs access to push to main
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          # Needs access to publish to npm
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
       - name: Set legend-transactional Package and Version
         id: set_env
         if: steps.changesets.outputs.published == 'true'

--- a/packages/legend-transac/package.json
+++ b/packages/legend-transac/package.json
@@ -18,7 +18,8 @@
   ],
   "repository": {
     "type": "git",
-    "url": "https://github.com/legendaryum-metaverse/legend-transactional/tree/main/packages/legend-transac"
+    "url": "git+https://github.com/legendaryum-metaverse/legend-transactional.git",
+    "directory": "packages/legend-transac"
   },
   "private": false,
   "publishConfig": {


### PR DESCRIPTION
## Summary

Switches `release.yml` to **npm Trusted Publishing** via OIDC (no long-lived `NPM_TOKEN`). A trusted publisher targeting this repo + `release.yml` has been configured on npmjs.com for `@legend-libs/transactional`.

## Research notes (official docs + known issues)

- [npm docs — Trusted Publishers](https://docs.npmjs.com/trusted-publishers): requires **npm CLI ≥ 11.5.1** and **Node ≥ 22.14.0**, plus `id-token: write` permission and `registry-url` on `setup-node`.
- [GitHub Changelog — npm trusted publishing GA (2025-07-31)](https://github.blog/changelog/2025-07-31-npm-trusted-publishing-with-oidc-is-generally-available/).
- [npm/cli#8976](https://github.com/npm/cli/issues/8976) and [npm/cli#8730](https://github.com/npm/cli/issues/8730): scoped packages have hit transient `E404` failures with OIDC + changesets/action — root cause not fully resolved upstream, but defensive fixes in this PR cover the common pitfalls (repo URL parseable for provenance, explicit `--provenance`).
- [changesets/action#515](https://github.com/changesets/action/issues/515): there's a longer-term ask to split versioning and publishing workflows so OIDC environment-protection can gate only the publish job. Out of scope here — we keep one workflow.
- [philna.sh — trusted publishing pitfalls](https://philna.sh/blog/2026/01/28/trusted-publishing-npm/): explicit `NPM_CONFIG_PROVENANCE` recommended even though docs imply it's automatic.

## Changes

### `.github/workflows/release.yml`

| Change | Why |
|---|---|
| `permissions: id-token: write` | Required for GHA to mint OIDC tokens npm verifies |
| explicit `contents: write` + `pull-requests: write` | Adding a `permissions` block drops defaults — needed so changesets/action can push the version PR |
| `node-version: 20` → `22` | Matches `engines.node >=22.0.0`; brings ≥22.14 minor for trusted publishing |
| `setup-node` `registry-url: 'https://registry.npmjs.org'` | npm CLI uses this to know where to send the OIDC handshake |
| `npm install -g npm@latest` step | Trusted publishing CLI support is in npm ≥ 11.5.1 |
| `NPM_CONFIG_PROVENANCE: true` env | Defensive — auto-enabled under OIDC in modern npm but explicitly turning it on avoids edge cases |
| Removed `NPM_TOKEN` env from `changesets/action` | No long-lived secret needed |
| `timeout-minutes: 2` → `5` | Cushion for OIDC handshake + publish |

### `packages/legend-transac/package.json`

`repository.url` changed from a browser tree URL (`/tree/main/...`) to the canonical `git+https://github.com/legendaryum-metaverse/legend-transactional.git` plus a `directory` pointer. Provenance attestations link the published artifact back to a specific git commit and need a parseable git URL.

## Test plan

- [ ] PR CI green (`pull_request_to_main` runs `code_quality_check`)
- [ ] After merge: any subsequent changeset PR triggers `release.yml` publishing `@legend-libs/transactional` via OIDC, no `NPM_TOKEN`
- [ ] npm package page shows a **Provenance** badge
- [ ] **Then** delete `NPM_TOKEN` from repo secrets

## Checked but not changed

- `actions/check-changeset/` — only used by `new-pr-to-main.yaml`; release flow unaffected
- `scripts/clean-project.sh` — unrelated

🤖 Generated with [Claude Code](https://claude.com/claude-code)