### PR TITLE
chore: validate OIDC trusted publishing end-to-end

### DIFF
--- a/.changeset/test-oidc-publish.md
+++ b/.changeset/test-oidc-publish.md
@@ -1,0 +1,5 @@
+---
+'@legend-libs/transactional': patch
+---
+
+Validate OIDC trusted publishing path end-to-end (no NPM_TOKEN, with provenance).

--- a/packages/legend-transac/src/index.ts
+++ b/packages/legend-transac/src/index.ts
@@ -4,4 +4,4 @@ export * from './Connections';
 export * from './constants';
 export * from './Consumer';
 export * from './utils';
-// dummy comment to trigger CI on changeset-only PR
+// dummy edit to trigger CI on changeset-only PR (OIDC test)


### PR DESCRIPTION
## Summary

Drives the next `@legend-libs/transactional` release through the **trusted-publishing** flow that landed in #393.

## Expected sequence

1. CI on this PR is green (`pull_request_to_main` job).
2. Merge this PR → `release.yml` runs on `main`.
3. `changesets/action` opens an auto `[ci] release` PR bumping to `3.0.2`.
4. Merge that release PR → `release.yml` runs again.
5. **Publish step uses OIDC** — no `NPM_TOKEN` referenced, GitHub mints a short-lived token, npm verifies the trusted publisher (`legendaryum-metaverse/legend-transactional` + `release.yml`) and accepts the publish.
6. Package on npm shows a **Provenance** badge linking to this commit.
7. Slack notification fires with new package URL.

## After confirmation

- Delete the now-unused `NPM_TOKEN` GitHub secret.
- The dummy comment in `src/index.ts` only exists so this PR isn't markdown-only (otherwise `new-pr-to-main.yaml`'s `paths-ignore` skips CI). It can stay until the next real edit overwrites it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)