### PR TITLE
chore: re-test OIDC trusted publishing under Node 24

### DIFF
--- a/.changeset/test-oidc-node24.md
+++ b/.changeset/test-oidc-node24.md
@@ -1,0 +1,5 @@
+---
+'@legend-libs/transactional': patch
+---
+
+Re-run OIDC trusted publishing flow under Node 24 (npm 11.x bundled).

--- a/.changeset/test-oidc-publish.md
+++ b/.changeset/test-oidc-publish.md
@@ -1,5 +1,0 @@
----
-'@legend-libs/transactional': patch
----
-
-Validate OIDC trusted publishing path end-to-end (no NPM_TOKEN, with provenance).

--- a/packages/legend-transac/src/index.ts
+++ b/packages/legend-transac/src/index.ts
@@ -4,4 +4,4 @@ export * from './Connections';
 export * from './constants';
 export * from './Consumer';
 export * from './utils';
-// dummy edit to trigger CI on changeset-only PR (OIDC test)
+// dummy edit — trigger CI under Node 24 OIDC test (PR #396)


### PR DESCRIPTION
## Summary

Adds another patch changeset to drive a release through `release.yml` after the direct-to-main fix `1ec63c6` switched the runner to **Node 24** (npm 11.x bundled, OIDC trusted publishing supported out of the box).

## Expected sequence

1. Merge this PR → `release.yml` runs on `main`.
2. `changesets/action` opens (or updates) the auto `[ci] release` PR.
3. Merge that release PR → `release.yml` publishes `@legend-libs/transactional` via OIDC.
4. npm package page shows a **Provenance** badge.
5. **Then** delete `NPM_TOKEN` from repo secrets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)