### PR TITLE
Feat/siplei

### DIFF
--- a/.changeset/lucky-drinks-make.md
+++ b/.changeset/lucky-drinks-make.md
@@ -1,0 +1,5 @@
+---
+'@legend-libs/transactional': major
+---
+
+add siplei

--- a/packages/legend-transac/jest.config.js
+++ b/packages/legend-transac/jest.config.js
@@ -1,0 +1,11 @@
+/** @type {import('ts-jest').JestConfigWithTsJest} */
+module.exports = {
+  testPathIgnorePatterns: ['/node_modules/', '/dist/'],
+  coverageProvider: 'v8',
+  transform: {
+    // Pinned rather than inherited from tsconfig: the swc in this workspace
+    // predates es2023 and fails to deserialize it.
+    '^.+\\.(t|j)sx?$': ['@swc/jest', {jsc: {target: 'es2022'}}],
+  },
+  reporters: [['github-actions', {silent: false}], 'summary'],
+};

--- a/packages/legend-transac/package.json
+++ b/packages/legend-transac/package.json
@@ -37,7 +37,8 @@
     "lint": "eslint --ext .ts src",
     "lint:fix": "eslint --fix --ext .ts src",
     "type-check": "tsc --noEmit --project tsconfig.json",
-    "prebuild": "pnpm run type-check"
+    "prebuild": "pnpm run type-check",
+    "test": "jest --passWithNoTests"
   },
   "dependencies": {
     "@types/amqplib": "^0.10.8",

--- a/packages/legend-transac/src/@types/event/consumer.ts
+++ b/packages/legend-transac/src/@types/event/consumer.ts
@@ -7,6 +7,11 @@ export interface EventsHandler<T extends MicroserviceEvent> {
   // Guard the index access so TS 5.9+ is satisfied without changing public API
   payload: EventPayload[T & keyof EventPayload];
   channel: EventsConsumeChannel;
+  /**
+   * The SIPLEI operation the event belongs to. `undefined` when the publisher
+   * did not set it, which is expected during the migration window.
+   */
+  operationId: string | undefined;
 }
 /**
  * Represents the events emitted by a microservice to Legendaryum.

--- a/packages/legend-transac/src/@types/event/events.ts
+++ b/packages/legend-transac/src/@types/event/events.ts
@@ -142,6 +142,16 @@ export interface EventPayload {
     blockExpirationHours?: number;
   };
   /**
+   * Event published when an operation is created. identity_mode is immutable
+   * once an operation exists, so this creation-time event is the only one a
+   * consumer needs to build a local {operationId -> identityMode} projection
+   * (IDR-01, MODULO-IDENTITY-RESOLVER.md).
+   */
+  'auth.operation_created': {
+    operationId: string;
+    identityMode: 'delegated' | 'managed';
+  };
+  /**
    * Event published when a mission is created and submitted for review.
    */
   'legend_missions.new_mission_created': {
@@ -747,6 +757,7 @@ export const microserviceEvent = {
   'AUTH.LOGOUT_USER': 'auth.logout_user',
   'AUTH.NEW_USER': 'auth.new_user',
   'AUTH.BLOCKED_USER': 'auth.blocked_user',
+  'AUTH.OPERATION_CREATED': 'auth.operation_created',
   'LEGEND_MISSIONS.NEW_MISSION_CREATED': 'legend_missions.new_mission_created',
   'LEGEND_MISSIONS.ONGOING_MISSION': 'legend_missions.ongoing_mission',
   'LEGEND_MISSIONS.MISSION_FINISHED': 'legend_missions.mission_finished',

--- a/packages/legend-transac/src/@types/event/events.ts
+++ b/packages/legend-transac/src/@types/event/events.ts
@@ -628,6 +628,20 @@ export interface EventPayload {
     occurredAt: string;
   };
   //////////////////////////////////////////////////////////////////////////////////////////////////////
+  // PLATFORM EVENTS - Level 1 entitlements (operation pays SIPLEI), see legend-billing/docs/ENTITLEMENTS.md
+  //////////////////////////////////////////////////////////////////////////////////////////////////////
+  /**
+   * An operation's effective feature set changed (plan assignment or feature
+   * override). Invalidation signal only, not a snapshot: consumers refetch
+   * from legend-billing rather than trust a payload that could drift from
+   * the feature schema. Fired from invalidateOperationFeatures() right after
+   * the local Redis key is dropped, so every service's cached copy expires
+   * together instead of independently on a 1h TTL.
+   */
+  'platform.operation_features_changed': {
+    operationId: string;
+  };
+  //////////////////////////////////////////////////////////////////////////////////////////////////////
   // LEGEND EVENTS - Event and registration domain events
   //////////////////////////////////////////////////////////////////////////////////////////////////////
   /**
@@ -796,6 +810,9 @@ export const microserviceEvent = {
   'BILLING.SUBSCRIPTION_RENEWED': 'billing.subscription_renewed',
   'BILLING.SUBSCRIPTION_CANCELED': 'billing.subscription_canceled',
   'BILLING.SUBSCRIPTION_EXPIRED': 'billing.subscription_expired',
+  ///////////////////////////
+  // PLATFORM EVENTS
+  'PLATFORM.OPERATION_FEATURES_CHANGED': 'platform.operation_features_changed',
   ///////////////////////////
   // LEGEND EVENTS
   'LEGEND_EVENTS.NEW_EVENT_CREATED': 'legend_events.new_event_created',

--- a/packages/legend-transac/src/Broker/PublishAuditEvent.ts
+++ b/packages/legend-transac/src/Broker/PublishAuditEvent.ts
@@ -1,5 +1,6 @@
 import { Channel } from 'amqplib';
 import { EventPayload, exchange, MicroserviceEvent } from '../@types';
+import { operationHeaders } from '../operation';
 
 /**
  * Publishes audit events to the direct audit exchange
@@ -25,6 +26,7 @@ export async function publishAuditEvent<T extends MicroserviceEvent>(
     const messageBuffer = Buffer.from(JSON.stringify(payload));
 
     channel.publish(exchange.Audit, routingKey, messageBuffer, {
+      headers: operationHeaders(),
       contentType: 'application/json',
       deliveryMode: 2, // persistent
     });

--- a/packages/legend-transac/src/Broker/PublishToExchange.ts
+++ b/packages/legend-transac/src/Broker/PublishToExchange.ts
@@ -4,6 +4,7 @@ import { getSendChannel } from './sendChannel';
 import { v7 as uuidv7 } from 'uuid';
 import { getStoredConfig } from '../Connections';
 import { publishAuditEvent } from './PublishAuditEvent';
+import { operationHeaders } from '../operation';
 /**
  * Publishes a microservice event to all subscribed microservices.
  *
@@ -38,6 +39,7 @@ export const publishEvent = async <T extends MicroserviceEvent>(
       ...getEventObject(event),
       // key para emitir eventos a todos los micros, todos los micros tienen el bind al exchange Matching
       'all-micro': 'yes',
+      ...operationHeaders(),
     },
     messageId,
     appId: publisherMicroservice,

--- a/packages/legend-transac/src/Broker/SendToQueue.ts
+++ b/packages/legend-transac/src/Broker/SendToQueue.ts
@@ -1,5 +1,6 @@
 import { CommenceSaga, queue, SagaCommencePayload, SagaTitle } from '../@types';
 import { getSendChannel } from './sendChannel';
+import { operationHeaders } from '../operation';
 /**
  * Sends a message payload to a specified queue.
  *
@@ -21,6 +22,7 @@ export const sendToQueue =
     // so we'll ignore it.
     channel.sendToQueue(queueName, Buffer.from(JSON.stringify(payload)), {
       persistent: true,
+      headers: operationHeaders(),
     });
   };
 /**

--- a/packages/legend-transac/src/Consumer/callbacks/commenceSaga.ts
+++ b/packages/legend-transac/src/Consumer/callbacks/commenceSaga.ts
@@ -2,6 +2,7 @@ import { CommenceSagaEvents, CommenceSaga, SagaTitle } from '../../@types';
 import { Channel, ConsumeMessage } from 'amqplib';
 import { Emitter } from 'mitt';
 import { SagaCommenceConsumeChannel } from '../channels/CommenceSaga';
+import { operationFromHeaders, withOperation } from '../../operation';
 /**
  * Callback function for consuming a saga commence event.
  *
@@ -29,6 +30,7 @@ export const commenceSagaConsumeCallback = <U extends SagaTitle>(
     return;
   }
   const responseChannel = new SagaCommenceConsumeChannel(channel, msg, queueName);
+  const operationId = operationFromHeaders(msg.properties.headers as Record<string, unknown> | undefined);
 
-  e.emit(saga.title, { saga, channel: responseChannel });
+  withOperation(operationId, () => e.emit(saga.title, { saga, channel: responseChannel }));
 };

--- a/packages/legend-transac/src/Consumer/callbacks/event.ts
+++ b/packages/legend-transac/src/Consumer/callbacks/event.ts
@@ -5,6 +5,7 @@ import { EventPayload, MicroserviceConsumeEvents, microserviceEvent, Microservic
 import { publishAuditEvent } from '../../Broker/PublishAuditEvent';
 import { extractMicroserviceFromQueue } from '../../utils';
 import { v7 as uuidv7 } from 'uuid';
+import { operationFromHeaders, reportMissingOperation, withOperation } from '../../operation';
 
 /**
  * Callback function for consuming and handling microservice events.
@@ -93,17 +94,24 @@ export const eventCallback = <U extends MicroserviceEvent>(
     publisherMicroservice = 'unknown';
   }
 
+  const operationId = operationFromHeaders(headers);
+  if (operationId === undefined) {
+    reportMissingOperation(receiverMicroservice, receivedEvent);
+  }
+
   //fire-and-forget -> Emit the audit.received event (never fail the main flow if audit fails)
-  publishAuditEvent(channel, 'audit.received', {
-    publisher_microservice: publisherMicroservice,
-    receiver_microservice: receiverMicroservice,
-    received_event: receivedEvent,
-    received_at: timestamp,
-    queue_name: queueName,
-    event_id,
-  }).catch((error) => {
-    console.error('Failed to emit audit.received event:', error);
-  });
+  withOperation(operationId, () =>
+    publishAuditEvent(channel, 'audit.received', {
+      publisher_microservice: publisherMicroservice,
+      receiver_microservice: receiverMicroservice,
+      received_event: receivedEvent,
+      received_at: timestamp,
+      queue_name: queueName,
+      event_id,
+    }).catch((error) => {
+      console.error('Failed to emit audit.received event:', error);
+    }),
+  );
 
   const responseChannel = new EventsConsumeChannel(
     channel,
@@ -113,10 +121,13 @@ export const eventCallback = <U extends MicroserviceEvent>(
     receivedEvent,
     event_id,
     publisherMicroservice,
+    operationId,
   );
 
   // si event.length > 1, a esta altura todos los eventos son válidos y se pueden emitir. Recordar llego un solo mensaje con extra headers.
   // Sin embargo, el payload es tipado para cada evento.
   // Mismo payload para dos handlers distintos, a menos que la relación con el evento en el proceso sea importante se podría refactorizar
-  e.emit(event[0], { payload, channel: responseChannel });
+  // Running the handler inside the scope makes the operation propagate to
+  // anything it publishes, with no code in the consuming service.
+  withOperation(operationId, () => e.emit(event[0], { payload, channel: responseChannel, operationId }));
 };

--- a/packages/legend-transac/src/Consumer/callbacks/saga.ts
+++ b/packages/legend-transac/src/Consumer/callbacks/saga.ts
@@ -1,6 +1,7 @@
 import { SagaConsumeSagaEvents, SagaStep, AvailableMicroservices } from '../../@types';
 import { Channel, ConsumeMessage } from 'amqplib';
 import { Emitter } from 'mitt';
+import { operationFromHeaders, withOperation } from '../../operation';
 import { SagaConsumeChannel } from '../channels';
 /**
  * Callback function for consuming saga events/commands.
@@ -30,7 +31,8 @@ export const sagaConsumeCallback = <T extends AvailableMicroservices>(
     channel.nack(msg, false, false);
     return;
   }
-  const responseChannel = new SagaConsumeChannel(channel, msg, queueName, currentStep);
+  const operationId = operationFromHeaders(msg.properties.headers as Record<string, unknown> | undefined);
+  const responseChannel = new SagaConsumeChannel(channel, msg, queueName, currentStep, operationId);
 
-  e.emit(currentStep.command, { step: currentStep, channel: responseChannel });
+  withOperation(operationId, () => e.emit(currentStep.command, { step: currentStep, channel: responseChannel }));
 };

--- a/packages/legend-transac/src/Consumer/callbacks/sagaStep.ts
+++ b/packages/legend-transac/src/Consumer/callbacks/sagaStep.ts
@@ -3,6 +3,7 @@ import { Channel, ConsumeMessage } from 'amqplib';
 import { Emitter } from 'mitt';
 import { MicroserviceConsumeChannel } from '../channels';
 import { MicroserviceConsumeSagaEvents } from '../../@types/saga/microservice';
+import { operationFromHeaders, reportMissingOperation, withOperation } from '../../operation';
 /**
  * Callback function for consuming microservice events/commands.
  *
@@ -32,7 +33,13 @@ export const sagaStepCallback = <T extends AvailableMicroservices>(
     return;
   }
   const { command, sagaId, previousPayload } = currentStep;
-  const responseChannel = new MicroserviceConsumeChannel<T>(channel, msg, queueName, currentStep);
+  const operationId = operationFromHeaders(msg.properties.headers as Record<string, unknown> | undefined);
+  if (operationId === undefined) {
+    reportMissingOperation(currentStep.microservice, command);
+  }
+  const responseChannel = new MicroserviceConsumeChannel<T>(channel, msg, queueName, currentStep, operationId);
 
-  e.emit(command, { sagaId, payload: previousPayload, channel: responseChannel });
+  // Running the handler inside the scope makes the operation propagate to
+  // anything it publishes, with no code in the consuming service.
+  withOperation(operationId, () => e.emit(command, { sagaId, payload: previousPayload, channel: responseChannel }));
 };

--- a/packages/legend-transac/src/Consumer/channels/Events.ts
+++ b/packages/legend-transac/src/Consumer/channels/Events.ts
@@ -1,6 +1,7 @@
 import { Channel, ConsumeMessage } from 'amqplib';
 import ConsumeChannel from './Consume';
 import { publishAuditEvent } from '../../Broker/PublishAuditEvent';
+import { withOperation } from '../../operation';
 import { NACKING_DELAY_MS, MAX_OCCURRENCE } from '../../constants';
 
 /**
@@ -28,6 +29,7 @@ export class EventsConsumeChannel extends ConsumeChannel {
    * The microservice that originally published the event
    */
   private readonly publisherMicroservice: string;
+  private readonly operationId: string | undefined;
 
   /**
    * Creates a new EventsConsumeChannel instance
@@ -48,12 +50,14 @@ export class EventsConsumeChannel extends ConsumeChannel {
     processedEvent: string,
     eventId: string,
     publisherMicroservice: string,
+    operationId?: string,
   ) {
     super(channel, msg, queueName);
     this.processorMicroservice = processorMicroservice;
     this.processedEvent = processedEvent;
     this.eventId = eventId;
     this.publisherMicroservice = publisherMicroservice;
+    this.operationId = operationId;
   }
 
   /**
@@ -67,16 +71,18 @@ export class EventsConsumeChannel extends ConsumeChannel {
     // Then emit audit.processed event automatically
     const timestamp = Date.now(); // UNIX timestamp in milliseconds
 
-    publishAuditEvent(this.channel, 'audit.processed', {
-      publisher_microservice: this.publisherMicroservice,
-      processor_microservice: this.processorMicroservice,
-      processed_event: this.processedEvent,
-      processed_at: timestamp,
-      queue_name: this.queueName,
-      event_id: this.eventId, // UUID v7 from message properties for cross-event tracking
-    }).catch((error) => {
-      console.error('Failed to emit audit.processed event:', error);
-    });
+    withOperation(this.operationId, () =>
+      publishAuditEvent(this.channel, 'audit.processed', {
+        publisher_microservice: this.publisherMicroservice,
+        processor_microservice: this.processorMicroservice,
+        processed_event: this.processedEvent,
+        processed_at: timestamp,
+        queue_name: this.queueName,
+        event_id: this.eventId, // UUID v7 from message properties for cross-event tracking
+      }).catch((error) => {
+        console.error('Failed to emit audit.processed event:', error);
+      }),
+    );
   }
 
   /**
@@ -101,19 +107,21 @@ export class EventsConsumeChannel extends ConsumeChannel {
     // Emit audit.dead_letter event automatically
     const timestamp = Date.now();
 
-    publishAuditEvent(this.channel, 'audit.dead_letter', {
-      publisher_microservice: this.publisherMicroservice,
-      rejector_microservice: this.processorMicroservice,
-      rejected_event: this.processedEvent,
-      rejected_at: timestamp,
-      queue_name: this.queueName,
-      rejection_reason: 'delay',
-      retry_count: parentNack.count,
-      event_id: this.eventId, // UUID v7 from message properties for cross-event tracking
-    }).catch((error) => {
-      // Log but don't fail the nack operation
-      console.error('Failed to emit audit.dead_letter event:', error);
-    });
+    withOperation(this.operationId, () =>
+      publishAuditEvent(this.channel, 'audit.dead_letter', {
+        publisher_microservice: this.publisherMicroservice,
+        rejector_microservice: this.processorMicroservice,
+        rejected_event: this.processedEvent,
+        rejected_at: timestamp,
+        queue_name: this.queueName,
+        rejection_reason: 'delay',
+        retry_count: parentNack.count,
+        event_id: this.eventId, // UUID v7 from message properties for cross-event tracking
+      }).catch((error) => {
+        // Log but don't fail the nack operation
+        console.error('Failed to emit audit.dead_letter event:', error);
+      }),
+    );
 
     return parentNack;
   }
@@ -144,19 +152,21 @@ export class EventsConsumeChannel extends ConsumeChannel {
     // Emit audit.dead_letter event automatically
     const timestamp = Date.now();
 
-    publishAuditEvent(this.channel, 'audit.dead_letter', {
-      publisher_microservice: this.publisherMicroservice,
-      rejector_microservice: this.processorMicroservice,
-      rejected_event: this.processedEvent,
-      rejected_at: timestamp,
-      queue_name: this.queueName,
-      rejection_reason: 'fibonacci_strategy',
-      retry_count: parentNack.count,
-      event_id: this.eventId, // UUID v7 from message properties for cross-event tracking
-    }).catch((error) => {
-      // Log but don't fail the nack operation
-      console.error('Failed to emit audit.dead_letter event:', error);
-    });
+    withOperation(this.operationId, () =>
+      publishAuditEvent(this.channel, 'audit.dead_letter', {
+        publisher_microservice: this.publisherMicroservice,
+        rejector_microservice: this.processorMicroservice,
+        rejected_event: this.processedEvent,
+        rejected_at: timestamp,
+        queue_name: this.queueName,
+        rejection_reason: 'fibonacci_strategy',
+        retry_count: parentNack.count,
+        event_id: this.eventId, // UUID v7 from message properties for cross-event tracking
+      }).catch((error) => {
+        // Log but don't fail the nack operation
+        console.error('Failed to emit audit.dead_letter event:', error);
+      }),
+    );
 
     return parentNack;
   }

--- a/packages/legend-transac/src/Consumer/channels/Step.ts
+++ b/packages/legend-transac/src/Consumer/channels/Step.ts
@@ -2,6 +2,7 @@ import { queue, status, AvailableMicroservices, SagaStep } from '../../@types';
 import { sendToQueue } from '../../Broker';
 import ConsumeChannel from './Consume';
 import { Channel, ConsumeMessage } from 'amqplib';
+import { withOperation } from '../../operation';
 /**
  * Represents a **_consume_** channel for a specific microservice.
  * Extends the abstract ConsumeChannel class.
@@ -15,6 +16,12 @@ export class MicroserviceConsumeChannel<T extends AvailableMicroservices> extend
   protected readonly step: SagaStep<T>;
 
   /**
+   * The operation (tenant) the consumed step belongs to, so the reply to the
+   * saga carries it forward instead of dropping the tenant mid-transaction.
+   */
+  protected readonly operationId: string | undefined;
+
+  /**
    * Constructs a new instance of the ConsumeChannel class.
    *
    * @param {Channel} channel - The channel to interact with the message broker.
@@ -22,9 +29,16 @@ export class MicroserviceConsumeChannel<T extends AvailableMicroservices> extend
    * @param {string} queueName - The name of the queue from which the message was consumed.
    * @param {SagaStep} step - The saga step associated with the consumed message.
    */
-  public constructor(channel: Channel, msg: ConsumeMessage, queueName: string, step: SagaStep<T>) {
+  public constructor(
+    channel: Channel,
+    msg: ConsumeMessage,
+    queueName: string,
+    step: SagaStep<T>,
+    operationId?: string,
+  ) {
     super(channel, msg, queueName);
     this.step = step;
+    this.operationId = operationId;
   }
 
   ackMessage(payloadForNextStep: Record<string, unknown> = {}): void {
@@ -41,13 +55,15 @@ export class MicroserviceConsumeChannel<T extends AvailableMicroservices> extend
       ...metaData,
     };
 
-    sendToQueue(queue.ReplyToSaga, this.step)
-      .then(() => {
-        this.channel.ack(this.msg, false);
-      })
-      .catch((err) => {
-        console.error(err);
-      });
+    withOperation(this.operationId, () =>
+      sendToQueue(queue.ReplyToSaga, this.step)
+        .then(() => {
+          this.channel.ack(this.msg, false);
+        })
+        .catch((err) => {
+          console.error(err);
+        }),
+    );
   }
 }
 

--- a/packages/legend-transac/src/index.ts
+++ b/packages/legend-transac/src/index.ts
@@ -3,5 +3,6 @@ export * from './Broker';
 export * from './Connections';
 export * from './constants';
 export * from './Consumer';
+export * from './operation';
 export * from './utils';
 // dummy edit — trigger CI under Node 24 OIDC test (PR #396)

--- a/packages/legend-transac/src/operation.ts
+++ b/packages/legend-transac/src/operation.ts
@@ -56,3 +56,32 @@ export const operationHeaders = (): Record<string, string> => {
   const operationId = currentOperation();
   return operationId === undefined ? {} : { [OPERATION_HEADER]: operationId };
 };
+
+/**
+ * The operation as gRPC metadata, for an outgoing call.
+ *
+ * Same key and same shape as the AMQP headers on purpose: one name for the
+ * tenant across both transports. A call made with no operation in scope sends
+ * nothing, which is what keeps the permissive migration working.
+ *
+ * Kept transport-agnostic — a plain record instead of a grpc `Metadata` — so
+ * the library does not pick a gRPC client for the services that use it. Each
+ * one spreads this into whatever its own client expects.
+ */
+export const operationMetadata = (): Record<string, string> => operationHeaders();
+
+/**
+ * Reads the operation off an incoming gRPC call and runs the handler inside its
+ * scope, so anything the handler publishes carries the same tenant.
+ *
+ * Reading the value without binding the scope is the subtle half-fix: the
+ * handler filters its own queries correctly and then emits an event with no
+ * operation, which every consumer resolves to Legendaryum.
+ *
+ * `get` is whatever the caller's gRPC library offers, e.g.
+ * `(key) => call.metadata.get(key)[0]?.toString()`.
+ */
+export const withOperationFromMetadata = <R>(get: (key: string) => string | undefined, fn: () => R): R => {
+  const operationId = get(OPERATION_HEADER);
+  return withOperation(operationId === '' ? undefined : operationId, fn);
+};

--- a/packages/legend-transac/src/operation.ts
+++ b/packages/legend-transac/src/operation.ts
@@ -1,0 +1,58 @@
+import { AsyncLocalStorage } from 'node:async_hooks';
+
+/**
+ * The AMQP header carrying the SIPLEI operation identifier.
+ * The same key is used for gRPC metadata so there is a single name across transports.
+ */
+export const OPERATION_HEADER = 'x-operation-id';
+
+const storage = new AsyncLocalStorage<string | undefined>();
+
+type MissingOperationHook = (microservice: string, eventType: string) => void;
+
+let missingOperationHook: MissingOperationHook | undefined;
+
+/**
+ * Registers the callback invoked when a consumed message carries no operation.
+ * A hook keeps the library free of a metrics backend; services wire it to
+ * `events_without_operation_total`.
+ */
+export const setMissingOperationHook = (hook?: MissingOperationHook) => {
+  missingOperationHook = hook;
+};
+
+export const reportMissingOperation = (microservice: string, eventType: string) => {
+  missingOperationHook?.(microservice, eventType);
+};
+
+/**
+ * Runs `fn` with `operationId` bound to the async context, so anything it
+ * publishes propagates the operation without explicit plumbing.
+ */
+export const withOperation = <R>(operationId: string | undefined, fn: () => R): R => storage.run(operationId, fn);
+
+/** Returns the operation bound to the current async context, if any. */
+export const currentOperation = (): string | undefined => storage.getStore();
+
+export const operationFromHeaders = (headers?: Record<string, unknown> | null): string | undefined => {
+  const value = headers?.[OPERATION_HEADER];
+  if (typeof value === 'string' && value.length > 0) {
+    return value;
+  }
+  // amqplib surfaces long strings as Buffer depending on the broker encoding.
+  if (Buffer.isBuffer(value)) {
+    const decoded = value.toString('utf8');
+    return decoded.length > 0 ? decoded : undefined;
+  }
+  return undefined;
+};
+
+/**
+ * Headers carrying the current operation, or an empty object when there is
+ * none. Spreading an empty object leaves published messages unchanged, which
+ * keeps the permissive migration window working.
+ */
+export const operationHeaders = (): Record<string, string> => {
+  const operationId = currentOperation();
+  return operationId === undefined ? {} : { [OPERATION_HEADER]: operationId };
+};

--- a/packages/legend-transac/test/operation.test.ts
+++ b/packages/legend-transac/test/operation.test.ts
@@ -1,0 +1,130 @@
+import {
+  OPERATION_HEADER,
+  currentOperation,
+  operationFromHeaders,
+  operationHeaders,
+  operationMetadata,
+  setMissingOperationHook,
+  withOperation,
+  withOperationFromMetadata,
+} from '../src/operation';
+
+afterEach(() => {
+  setMissingOperationHook(undefined);
+});
+
+describe('withOperation', () => {
+  it('binds the operation for anything running inside it', () => {
+    const seen = withOperation('op-brasil', () => currentOperation());
+    expect(seen).toBe('op-brasil');
+  });
+
+  // The scope has to end with the call. A leaked operation is worse than a
+  // missing one: the next message published would carry the previous tenant.
+  it('does not leak the operation outside its scope', () => {
+    withOperation('op-brasil', () => currentOperation());
+    expect(currentOperation()).toBeUndefined();
+  });
+
+  it('keeps the operation across an await', async () => {
+    const seen = await withOperation('op-brasil', async () => {
+      await Promise.resolve();
+      return currentOperation();
+    });
+    expect(seen).toBe('op-brasil');
+  });
+
+  // A consumer handling a message with no operation must not inherit whatever
+  // the previous one was bound to.
+  it('an inner scope with no operation shadows the outer one', () => {
+    const seen = withOperation('op-brasil', () => withOperation(undefined, () => currentOperation()));
+    expect(seen).toBeUndefined();
+  });
+});
+
+describe('operationFromHeaders', () => {
+  it('reads a plain string header', () => {
+    expect(operationFromHeaders({ [OPERATION_HEADER]: 'op-brasil' })).toBe('op-brasil');
+  });
+
+  // amqplib hands long strings back as Buffer depending on the broker encoding,
+  // so a Buffer here is a normal message, not a corrupt one.
+  it('reads a Buffer header', () => {
+    expect(operationFromHeaders({ [OPERATION_HEADER]: Buffer.from('op-brasil') })).toBe('op-brasil');
+  });
+
+  it.each([
+    ['no headers', undefined],
+    ['null headers', null],
+    ['empty object', {}],
+    ['empty string', { [OPERATION_HEADER]: '' }],
+    ['empty buffer', { [OPERATION_HEADER]: Buffer.from('') }],
+    ['wrong type', { [OPERATION_HEADER]: 42 }],
+  ])('returns undefined for %s', (_label, headers) => {
+    expect(operationFromHeaders(headers as Record<string, unknown> | null | undefined)).toBeUndefined();
+  });
+});
+
+describe('operationHeaders', () => {
+  it('carries the bound operation', () => {
+    const headers = withOperation('op-brasil', () => operationHeaders());
+    expect(headers).toEqual({ [OPERATION_HEADER]: 'op-brasil' });
+  });
+
+  // Spreading an empty object leaves a published message byte-for-byte as it
+  // was, which is what keeps un-migrated publishers working.
+  it('is empty with no operation, so a publish is left untouched', () => {
+    expect(operationHeaders()).toEqual({});
+  });
+
+  it('round-trips through operationFromHeaders', () => {
+    const headers = withOperation('op-brasil', () => operationHeaders());
+    expect(operationFromHeaders(headers)).toBe('op-brasil');
+  });
+});
+
+describe('operationMetadata', () => {
+  // Same key on both transports on purpose: one name for the tenant.
+  it('uses the same key as the AMQP headers', () => {
+    const metadata = withOperation('op-brasil', () => operationMetadata());
+    expect(metadata).toEqual({ [OPERATION_HEADER]: 'op-brasil' });
+  });
+});
+
+describe('withOperationFromMetadata', () => {
+  it('binds the operation an incoming call carried', () => {
+    const seen = withOperationFromMetadata(
+      (key) => (key === OPERATION_HEADER ? 'op-brasil' : undefined),
+      () => currentOperation(),
+    );
+    expect(seen).toBe('op-brasil');
+  });
+
+  it('binds nothing when the call carried no operation', () => {
+    expect(withOperationFromMetadata(() => undefined, () => currentOperation())).toBeUndefined();
+  });
+
+  // An empty metadata value is absence, not an operation named "".
+  it('treats an empty value as absent', () => {
+    expect(withOperationFromMetadata(() => '', () => currentOperation())).toBeUndefined();
+  });
+});
+
+describe('missing operation hook', () => {
+  it('reports through the hook the services wire to their metrics', () => {
+    const seen: [string, string][] = [];
+    setMissingOperationHook((microservice, eventType) => seen.push([microservice, eventType]));
+
+    // eslint-disable-next-line @typescript-eslint/no-var-requires
+    const { reportMissingOperation } = require('../src/operation') as typeof import('../src/operation');
+    reportMissingOperation('social', 'auth.deleted_user');
+
+    expect(seen).toEqual([['social', 'auth.deleted_user']]);
+  });
+
+  it('is a no-op when nobody registered a hook, so the library needs no metrics backend', () => {
+    // eslint-disable-next-line @typescript-eslint/no-var-requires
+    const { reportMissingOperation } = require('../src/operation') as typeof import('../src/operation');
+    expect(() => reportMissingOperation('social', 'auth.deleted_user')).not.toThrow();
+  });
+});

--- a/packages/legend-transac/test/operation.test.ts
+++ b/packages/legend-transac/test/operation.test.ts
@@ -101,12 +101,22 @@ describe('withOperationFromMetadata', () => {
   });
 
   it('binds nothing when the call carried no operation', () => {
-    expect(withOperationFromMetadata(() => undefined, () => currentOperation())).toBeUndefined();
+    expect(
+      withOperationFromMetadata(
+        () => undefined,
+        () => currentOperation(),
+      ),
+    ).toBeUndefined();
   });
 
   // An empty metadata value is absence, not an operation named "".
   it('treats an empty value as absent', () => {
-    expect(withOperationFromMetadata(() => '', () => currentOperation())).toBeUndefined();
+    expect(
+      withOperationFromMetadata(
+        () => '',
+        () => currentOperation(),
+      ),
+    ).toBeUndefined();
   });
 });
 


### PR DESCRIPTION
## Qué

Paridad con Go y Rust para los micros TS.

## Cómo

`AsyncLocalStorage`. El consumidor abre el scope y `publishEvent` lee la operación de
ahí, así que **un micro TS no toca un solo call site de publicación**: le alcanza con
abrir el scope en su capa HTTP.

```ts
// Hono, una línea en el ServerBuilder
server.use('*', (c, next) => withOperation(getOperationId(c), next));

┌──────────────────────────────────────────────────────────┬─────────────────────────────────────────────────────┐
│                         Archivo                          │                     Qué aporta                      │
├──────────────────────────────────────────────────────────┼─────────────────────────────────────────────────────┤
│ operation.ts                                             │ scope, headers, metadata de gRPC, hook de faltantes │
├──────────────────────────────────────────────────────────┼─────────────────────────────────────────────────────┤
│ Consumer/callbacks/event.ts                              │ expone operationId y corre el handler en scope      │
├──────────────────────────────────────────────────────────┼─────────────────────────────────────────────────────┤
│ Consumer/callbacks/sagaStep.ts, saga.ts, commenceSaga.ts │ ídem para saga                                      │
├──────────────────────────────────────────────────────────┼─────────────────────────────────────────────────────┤
│ Consumer/channels/Step.ts                                │ el ack responde al saga con la operación            │
├──────────────────────────────────────────────────────────┼─────────────────────────────────────────────────────┤
│ Broker/*                                                 │ adjuntan el header al publicar                      │
├──────────────────────────────────────────────────────────┼─────────────────────────────────────────────────────┤
│ @types/event/events.ts                                   │ los dos eventos nuevos                              │
└──────────────────────────────────────────────────────────┴─────────────────────────────────────────────────────┘

Dos cosas que estaban rotas

Saga steps: igual que en Rust, el consumidor de eventos ataba la operación y el de
saga steps no. Un saga multi-micro perdía el tenant en el primer salto.

gRPC: los micros TS usan gRPC y la librería no les daba nada. Ningún cliente mandaba
x-operation-id, y social leía el header en su server sin atar el scope — o sea,
filtraba bien sus queries y después publicaba eventos sin operación, que todos los
consumidores resuelven a Legendaryum. Se agregan operationMetadata() y
withOperationFromMetadata(), sin dependencia de gRPC: devuelven un record plano
porque cada micro TS usa una librería distinta.

⚠️ Breaking

EventsHandler ahora incluye operationId: string | undefined — requerido, no
opcional, a propósito: obliga al consumidor a decidir qué hace con el tenant en vez de
ignorarlo por descuido. Rompe fixtures de test, no código de producción.

Changeset major → el release lo lleva a 4.0.0.

Verificación

21 tests nuevos (la librería no tenía ninguno). Cubren que el scope no se filtre
fuera de su llamada, que un scope interno sin operación tape al externo, que sobreviva a
un await, y que headers en Buffer se lean igual que en string.