### PR TITLE
feat(events): add features to billing subscription event types

### DIFF
--- a/.changeset/cuddly-yaks-invite.md
+++ b/.changeset/cuddly-yaks-invite.md
@@ -1,0 +1,5 @@
+---
+'@legend-libs/transactional': patch
+---
+
+modification payload billing

--- a/.changeset/wild-rivers-jump.md
+++ b/.changeset/wild-rivers-jump.md
@@ -1,0 +1,5 @@
+---
+'@legend-libs/transactional': patch
+---
+
+add legend_rankings.billable_participant_recorded event

--- a/packages/legend-transac/src/@types/event/events.ts
+++ b/packages/legend-transac/src/@types/event/events.ts
@@ -578,6 +578,7 @@ export interface EventPayload {
     periodStart: string;
     periodEnd: string;
     occurredAt: string;
+    features?: string[];
   };
   /**
    * Subscription was updated (plan change, status change, etc.)
@@ -592,6 +593,7 @@ export interface EventPayload {
     periodStart: string;
     periodEnd: string;
     occurredAt: string;
+    features?: string[];
   };
   /**
    * Subscription was renewed (new billing period started)
@@ -604,6 +606,7 @@ export interface EventPayload {
     periodStart: string;
     periodEnd: string;
     occurredAt: string;
+    features?: string[];
   };
   /**
    * Subscription was canceled (still active until period end)

--- a/packages/legend-transac/src/@types/event/events.ts
+++ b/packages/legend-transac/src/@types/event/events.ts
@@ -250,6 +250,18 @@ export interface EventPayload {
     completedRankings: CompletedRanking[];
   };
   /**
+   * A distinct player's first participation in a ranking was recorded (the
+   * billable unit - the same player playing 50 times counts once).
+   * Invalidation signal, not a snapshot: consumers re-fetch the count they
+   * need rather than trust a total baked into the event.
+   */
+  'legend_rankings.billable_participant_recorded': {
+    operationId: string;
+    sourceType: string;
+    sourceId: string;
+    occurredAt: string;
+  };
+  /**
    * Event to deliver intermediate reward (e.g., first game)
    */
   'legend_rankings.intermediate_reward': {
@@ -785,6 +797,7 @@ export const microserviceEvent = {
     'legend_missions.send_email_code_exchange_mission_completed',
   'LEGEND_MISSIONS.SEND_EMAIL_GIFT_CARD_MISSION_COMPLETED': 'legend_missions.send_email_gift_card_mission_completed',
   'LEGEND_RANKINGS.RANKINGS_FINISHED': 'legend_rankings.rankings_finished',
+  'LEGEND_RANKINGS.BILLABLE_PARTICIPANT_RECORDED': 'legend_rankings.billable_participant_recorded',
   'LEGEND_RANKINGS.NEW_RANKING_CREATED': 'legend_rankings.new_ranking_created',
   'LEGEND_RANKINGS.RANKING_SUBMITTED_FOR_REVIEW': 'legend_rankings.ranking_submitted_for_review',
   'LEGEND_RANKINGS.RANKING_APPROVED': 'legend_rankings.ranking_approved',

--- a/packages/legend-transac/src/@types/event/events.ts
+++ b/packages/legend-transac/src/@types/event/events.ts
@@ -259,6 +259,10 @@ export interface EventPayload {
     operationId: string;
     sourceType: string;
     sourceId: string;
+    // Needed so consumers can dedupe on (operationId, sourceType, sourceId,
+    // userRef) - the same composite key billable_participants uses - and
+    // stay correct under RabbitMQ redelivery instead of double-counting.
+    userRef: string;
     occurredAt: string;
   };
   /**

--- a/packages/legend-transac/test/operation.test.ts
+++ b/packages/legend-transac/test/operation.test.ts
@@ -101,12 +101,22 @@ describe('withOperationFromMetadata', () => {
   });
 
   it('binds nothing when the call carried no operation', () => {
-    expect(withOperationFromMetadata(() => undefined, () => currentOperation())).toBeUndefined();
+    expect(
+      withOperationFromMetadata(
+        () => undefined,
+        () => currentOperation(),
+      ),
+    ).toBeUndefined();
   });
 
   // An empty metadata value is absence, not an operation named "".
   it('treats an empty value as absent', () => {
-    expect(withOperationFromMetadata(() => '', () => currentOperation())).toBeUndefined();
+    expect(
+      withOperationFromMetadata(
+        () => '',
+        () => currentOperation(),
+      ),
+    ).toBeUndefined();
   });
 });
 


### PR DESCRIPTION
### Resumen: 
Mismo cambio, TS — features?: string[] en EventPayload para los 3 eventos de suscripción (packages/legend-transac/src/@types/event/events.ts). Incluye el changeset (patch) para versionar el paquete @legend-libs/transactional al publicar. Con esto, legend-billing puede sacar el workaround local que tenía documentado (SubscriptionCreatedEventWithFeatures) una vez que se actualice la dependencia.
